### PR TITLE
[Modfied] How To Guides Sidebar

### DIFF
--- a/docs/How-To-Guides/how-to-create-play.md
+++ b/docs/How-To-Guides/how-to-create-play.md
@@ -46,7 +46,8 @@ Parameter details
 
 | Field           | Mandatory? | Description                                                                                                                                                                                                                                                                                                                                                                                                               |
 | --------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Name            | YES        | It is a description of the play for users to understand it better. The maximum number of allowed characters is 1024.                                                                                                                                                                                                                                                                                                      |
+| Name            | YES        | Every play should have a name that is relatable to the play's idea.                                                                                                                                                                                                                                                                                                                                                       |
+| Description     | YES        | It is a description of the play for users to understand it better. The maximum number of allowed characters is 1024.                                                                                                                                                                                                                                                                                                      |
 | Issue           | YES        | Every play should be mapped with an issue. Select it here.                                                                                                                                                                                                                                                                                                                                                                |
 | Language        | YES        | Let the application know your choice of script. It supports both <b>JavaScript</b> and <b>TypeScript</b>. You can pick either of it.                                                                                                                                                                                                                                                                                      |
 | Style           | NO         | Let the application know your choice of style. It supports both <b>css</b> and <b>scss</b>. You can pick either of it.                                                                                                                                                                                                                                                                                                    |
@@ -75,9 +76,9 @@ Parameter details
   `bash
 npx create-react-play@latest -c <the_play_id>
 `
-  <p align="center">
-  <img src="https://res.cloudinary.com/atapas/image/upload/v1675172352/ReactPlay/Screenshot_2023-01-31_at_7.06.07_PM_jhbcbl.png" alt="copy-command" />
-  </p>
+    <p align="center">
+    <img src="https://res.cloudinary.com/atapas/image/upload/v1675172352/ReactPlay/Screenshot_2023-01-31_at_7.06.07_PM_jhbcbl.png" alt="copy-command" />
+    </p>
 
 - Start the application
 


### PR DESCRIPTION
Fixes:  #58
**Issue:**
Sidebar -> How To Guides -> How To Create a Play -> Parameter Details
1. "Name" field description is not relatable to this field
2. Missing "Description" field

**Solution**
Sidebar -> How To Guides -> How To Create a Play -> Parameter Details
1. Markdown code for "Name" filed to be replace.
`| Name  | YES | Every play should have a name which is relatable with play idea. |
`
2. Markdown code for "Description" field to be create
`| Description | YES | It is a description of the play for users to understand it better. The maximum number of allowed characters is 1024. |
`
