### PR TITLE
[Solved] bug-report-#62->show code snipped instead of image

### DIFF
--- a/docs/How-To-Guides/how-to-create-play.md
+++ b/docs/How-To-Guides/how-to-create-play.md
@@ -76,9 +76,9 @@ Parameter details
   `bash
 npx create-react-play@latest -c <the_play_id>
 `
-    <p align="center">
-    <img src="https://res.cloudinary.com/atapas/image/upload/v1675172352/ReactPlay/Screenshot_2023-01-31_at_7.06.07_PM_jhbcbl.png" alt="copy-command" />
-    </p>
+  <p align="center">
+      <img src="https://res.cloudinary.com/atapas/image/upload/v1675172352/ReactPlay/Screenshot_2023-01-31_at_7.06.07_PM_jhbcbl.png" alt="copy-command" />
+  </p>
 
 - Start the application
 


### PR DESCRIPTION
Path: How to guides -> How to create a play

On this page instead of an image it shows the code of the image. Here used markdown format and due to an unexpected space, the image code is delivered as a code snipped format. That's why it shows the code instead of the image. Now solved this issue.