### PR TITLE
Facebook link added in contribution guide section

### DIFF
--- a/docs/How-To-Guides/how-to-create-play.md
+++ b/docs/How-To-Guides/how-to-create-play.md
@@ -92,8 +92,6 @@ Parameter details
   npm run start
   ```
 
-```
-
 - You should now see your play added to the [play list](http://localhost:3000/plays) page.
 <p align="center">
   <img src="https://res.cloudinary.com/atapas/image/upload/v1675172352/ReactPlay/Screenshot_2023-01-31_at_7.06.55_PM_gyck2r.png" alt="play" />
@@ -123,4 +121,3 @@ Once the Pull Request is approved and merged, we will notify you and add you as 
 ## ✋ Need Help?
 
 You can reach out to us at [ReactPlay Twitter Handle | @ReactPlayIO](https://twitter.com/ReactPlayIO) with a DM. Additionally, feel free to join our [Discord community](https://discord.gg/vrTxWUP8Am) for discussions.
-```

--- a/docs/How-To-Guides/how-to-create-play.md
+++ b/docs/How-To-Guides/how-to-create-play.md
@@ -72,10 +72,12 @@ Parameter details
   npx create-react-play -c <the_play_id>
   ```
 
-  **Note:** If the play folder `<reactplay_directory>/src/plays/<your_play_name>` remain empty after running above command that means you might be in some older version of the package. Use `@latest` in that case
-  `bash
-npx create-react-play@latest -c <the_play_id>
-`
+  **Note:** If the play folder `<reactplay_directory>/src/plays/<your_play_name>` remain empty after running above command that means you might be in some older version of the package. Use `@latest` in that case.
+
+  ```bash
+  npx create-react-play@latest -c <the_play_id>
+  ```
+
   <p align="center">
       <img src="https://res.cloudinary.com/atapas/image/upload/v1675172352/ReactPlay/Screenshot_2023-01-31_at_7.06.07_PM_jhbcbl.png" alt="copy-command" />
   </p>
@@ -89,6 +91,8 @@ npx create-react-play@latest -c <the_play_id>
 
   npm run start
   ```
+
+```
 
 - You should now see your play added to the [play list](http://localhost:3000/plays) page.
 <p align="center">
@@ -119,3 +123,4 @@ Once the Pull Request is approved and merged, we will notify you and add you as 
 ## ✋ Need Help?
 
 You can reach out to us at [ReactPlay Twitter Handle | @ReactPlayIO](https://twitter.com/ReactPlayIO) with a DM. Additionally, feel free to join our [Discord community](https://discord.gg/vrTxWUP8Am) for discussions.
+```

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -29,7 +29,7 @@ We also love `typo` issues. If you find a typo somewhere, get in touch us and cr
 - Found a bug. Great! Go ahead and open a [bug report](https://github.com/reactplay/react-play/issues/new?assignees=&labels=bug&template=bug-report.yml&title=%F0%9F%90%9B+%5BBug+report%5D%3A+)
 - You could also improve the [docs](https://github.com/reactplay/docs) which would help us immensely.
 - You could give us feedback, suggestions and help us improve our UX.
-- Have interest in interacting with public, you are welcome to manage our social media handles like [Twitter](https://twitter.com/ReactPlayIO), [LinkedIn](https://www.linkedin.com/company/reactplay/) and [Facebook](https://web.facebook.com/groups/reactplay).
+- Have an interest in interacting with the public? You are welcome to manage our social media handles like [Twitter](https://twitter.com/ReactPlayIO), [LinkedIn](https://www.linkedin.com/company/reactplay/), and [Facebook](https://web.facebook.com/groups/reactplay).
 - Have a flair for writing, you could publish articles on our [blog](https://blog.reactplay.io/).
 - You could also be our advocate and help us in arranging events, sponsors and support.
 

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -29,7 +29,7 @@ We also love `typo` issues. If you find a typo somewhere, get in touch us and cr
 - Found a bug. Great! Go ahead and open a [bug report](https://github.com/reactplay/react-play/issues/new?assignees=&labels=bug&template=bug-report.yml&title=%F0%9F%90%9B+%5BBug+report%5D%3A+)
 - You could also improve the [docs](https://github.com/reactplay/docs) which would help us immensely.
 - You could give us feedback, suggestions and help us improve our UX.
-- Have interest in interacting with public, you are welcome to manage our social media handles like [Twitter](https://twitter.com/ReactPlayIO) and [LinkedIn](https://www.linkedin.com/company/reactplay/).
+- Have interest in interacting with public, you are welcome to manage our social media handles like [Twitter](https://twitter.com/ReactPlayIO), [LinkedIn](https://www.linkedin.com/company/reactplay/) and [Facebook](https://web.facebook.com/groups/reactplay).
 - Have a flair for writing, you could publish articles on our [blog](https://blog.reactplay.io/).
 - You could also be our advocate and help us in arranging events, sponsors and support.
 


### PR DESCRIPTION
Issue No: #65
Path: Contribution Guide -> Areas of Contribution
On that page, I added "Facebook" also as a social media contribution section along with Twitter and LinkedIn.