### PR TITLE
fix: [Issue #71] fixed typo/error in useGitHub code snippet

### DIFF
--- a/docs/apis-hook.md
+++ b/docs/apis-hook.md
@@ -196,7 +196,7 @@ const { data, error, isLoading } = useGitHub(`username`);
 
 return (
   <div className="data-container">
-    {loading && <p>Loading...</p>}
+    {isLoading && <p>Loading...</p>}
     {error && <p>{error?.message ?? "Something went wrong"}</p>}
     {data && <p>{data.login}</p>}
   </div>


### PR DESCRIPTION
Fixes: Issue: [Bug report]: Typo/Error in Code snippet of useGitHub hook #71 

Replaced `loading` by `isLoading` in the Line#4 of the code snippet.

Deploy Preview Link:
https://deploy-preview-72--react-play-docs.netlify.app/apis-hook#usegithub

Screenshot from local host for reference:

![React Play Docs Fix highlighted in useGitHub for Contribution](https://github.com/reactplay/docs/assets/91183455/12baf1c6-47d4-4fd8-a00b-11733c4e6d37)
